### PR TITLE
Modify basic auth lambda to use supported Node.js 12 runtime

### DIFF
--- a/cloudformation/basic-auth-edge-lambda.yaml
+++ b/cloudformation/basic-auth-edge-lambda.yaml
@@ -60,7 +60,7 @@ Resources:
       Handler: 'index.beforeOriginRequest'
       Role: !GetAtt EdgeLambdaRole.Arn
       Code:
-        ZipFile: !Sub "
+        ZipFile: !Sub |
           'use strict';
           const path = require('path');
 
@@ -133,8 +133,7 @@ Resources:
             }
             return null;
           };
-          "
-      Runtime: 'nodejs8.10'
+      Runtime: 'nodejs12.x'
       Timeout: '5'
       TracingConfig:
         Mode: 'Active'


### PR DESCRIPTION
Change runtime specification to "nodejs12.x" as Node.js 8.x is no longer supported.

This commit also modifies the lambda code specification to preserve newlines, which results in readable code in the AWS console lambda console.